### PR TITLE
Lint fixes

### DIFF
--- a/clustercontrol/manifests/init.pp
+++ b/clustercontrol/manifests/init.pp
@@ -13,7 +13,7 @@
 
 class clustercontrol (
   $is_controller            = true,
-  $clustercontrol_host      = '', 
+  $clustercontrol_host      = '',
   $ip_address               = $ipaddress,
   $api_token                = '',
   $ssh_user                 = 'root',
@@ -38,296 +38,299 @@ class clustercontrol (
     $service_status = 'stopped'
   }
   
-  if ($ssh_user == 'root') { 
+  if ($ssh_user == 'root') {
     $user_home            = '/root'
     $real_sudo_password   = undef
-  } else { 
-    $user_home            = "/home/$ssh_user"
+  } else {
+    $user_home            = "/home/${ssh_user}"
     $rssh_opts             = '-nqtt'
-    if ($sudo_password  != undef) { $real_sudo_password = "echo $sudo_password | sudo -S" } else { $real_sudo_password = 'sudo' }
+    if ($sudo_password  != undef) { $real_sudo_password = "echo ${sudo_password} | sudo -S" } else { $real_sudo_password = 'sudo' }
   }
   if ($ssh_key == '') {
-  	$ssh_identity     = "$user_home/.ssh/id_rsa_s9s"
-  	$ssh_identity_pub = "$user_home/.ssh/id_rsa_s9s.pub"
+    $ssh_identity     = "${user_home}/.ssh/id_rsa_s9s"
+    $ssh_identity_pub = "${user_home}/.ssh/id_rsa_s9s.pub"
   } else {
-  	$ssh_identity     = "$ssh_key"
-  	$ssh_identity_pub = "$ssh_key.pub"
+    $ssh_identity     = $ssh_key
+    $ssh_identity_pub = "${ssh_key}.pub"
   }
   
-  $backup_dir       = "$user_home/backups"
-  $staging_dir      = "$user_home/s9s_tmp"
+  $backup_dir       = "${user_home}/backups"
+  $staging_dir      = "${user_home}/s9s_tmp"
   
-  Exec { path => ['/usr/bin','/bin',"$mysql_basedir/bin"]}
+  Exec { path => ['/usr/bin','/bin',"${mysql_basedir}/bin"]}
   
   if $is_controller {
     
     include clustercontrol::params
-	  
-	  service { $clustercontrol::params::mysql_service :
-	    ensure       => running,
-	    enable       => true,
-	    hasrestart   => true,
-	    hasstatus    => true,
-	    require      => [
-	      Package[$clustercontrol::params::mysql_packages],
-	      File[$datadir],
-	      ],
-	    notify     => Exec['create-root-password'],
-	    subscribe  => File[$clustercontrol::params::mysql_cnf]
-	  }
-	  
-	  file { $clustercontrol::params::mysql_cnf :
-	    ensure   => present,
-	    content  => template('clustercontrol/my.cnf.erb'),
-	    owner    => root, group => root,
-	    mode     => 644
-	    }
-	  
-	  package { $clustercontrol::params::mysql_packages :
-	    ensure  => installed,
-	    notify  => Exec['disable-extra-security']
-	  }
-	  
-	  exec { 'create-root-password' :
-	    onlyif  => "mysqladmin -u root status",
-	    command => "mysqladmin -u root password \"$mysql_cmon_root_password\"",
-	    notify  => Exec[
-	      'grant-cmon-localhost', 
-	      'grant-cmon-127.0.0.1', 
-	      'grant-cmon-ip-address',
-	      'grant-cmon-fqdn'
-	      ]
-	  }
-	  
-	  exec { "grant-cmon-localhost" :
-	    unless  => "mysqladmin -u cmon -p \"$mysql_cmon_password\" -hlocalhost status",
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@localhost IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-	  }
-	  
-	  exec { "grant-cmon-127.0.0.1" :
-	    unless  => "mysqladmin -u cmon -p \"$mysql_cmon_password\" -h127.0.0.1 status",
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@127.0.0.1 IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-	  }
-	  
-	  exec { "grant-cmon-ip-address" :
-	    unless  => "mysqladmin -u cmon -p \"$mysql_cmon_password\" -h\"$ip_address\" status",
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"$ip_address\" IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-	  }
-	  
-	  exec { "grant-cmon-fqdn" :
-	    unless  => "mysqladmin -u cmon -p \"$mysql_cmon_password\" -h\"$fqdn\" status",
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"$fqdn\" IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-	  }
-	  
-	  exec { "create-cmon-db" :
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'CREATE SCHEMA IF NOT EXISTS cmon;'",
-	    notify  => Exec['import-cmon-db']
-	  }
-	
-	  exec { "create-dcps-db" :
-	    command => "mysql -u root -p\"$mysql_cmon_root_password\" -e 'CREATE SCHEMA IF NOT EXISTS dcps;'",
-	    notify  => Exec['import-dcps-db']
-	  }
-	  
-	  exec { "import-cmon-db" :
-	    onlyif  => [
-	      "test -f $clustercontrol::params::cmon_sql_path/cmon_db.sql",
-	      "test -f $clustercontrol::params::cmon_sql_path/cmon_data.sql"
-	    ],
-	    command => "mysql -f -u root -p\"$mysql_cmon_root_password\" cmon < $clustercontrol::params::cmon_sql_path/cmon_db.sql && \
-	    mysql -f -u root -p\"$mysql_cmon_root_password\" cmon < $clustercontrol::params::cmon_sql_path/cmon_data.sql",
-	    notify => Exec['configure-cmon-db']
-	  }
-	  
-	  exec { 'configure-cmon-db' :
-	    onlyif  => [
-        "test -f $clustercontrol::params::cmon_sql_path/cmon_db.sql",
-        "test -f $clustercontrol::params::cmon_sql_path/cmon_data.sql"
+    
+    service { $clustercontrol::params::mysql_service :
+      ensure    => running,
+      enable    => true,
+      hasrestart=> true,
+      hasstatus => true,
+      require   => [
+        Package[$clustercontrol::params::mysql_packages],
+        File[$datadir],
+        ],
+      notify     => Exec['create-root-password'],
+      subscribe  => File[$clustercontrol::params::mysql_cnf]
+    }
+    
+    file { $clustercontrol::params::mysql_cnf :
+      ensure => present,
+      content=> template('clustercontrol/my.cnf.erb'),
+      owner  => root,
+      group  => root,
+      mode   => '0644'
+      }
+    
+    package { $clustercontrol::params::mysql_packages :
+      ensure=> installed,
+      notify=> Exec['disable-extra-security']
+    }
+    
+    exec { 'create-root-password' :
+      onlyif  => 'mysqladmin -u root status',
+      command => "mysqladmin -u root password \"${mysql_cmon_root_password}\"",
+      notify  => Exec[
+        'grant-cmon-localhost',
+        'grant-cmon-127.0.0.1',
+        'grant-cmon-ip-address',
+        'grant-cmon-fqdn'
+        ]
+    }
+    
+    exec { 'grant-cmon-localhost' :
+      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -hlocalhost status",
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@localhost IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+    }
+    
+    exec { 'grant-cmon-127.0.0.1' :
+      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -h127.0.0.1 status",
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@127.0.0.1 IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+    }
+    
+    exec { 'grant-cmon-ip-address' :
+      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -h\"${ip_address}\" status",
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"${ip_address}\" IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+    }
+    
+    exec { 'grant-cmon-fqdn' :
+      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -h\"${fqdn}\" status",
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"${fqdn}\" IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+    }
+    
+    exec { 'create-cmon-db' :
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'CREATE SCHEMA IF NOT EXISTS cmon;'",
+      notify  => Exec['import-cmon-db']
+    }
+  
+    exec { 'create-dcps-db' :
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'CREATE SCHEMA IF NOT EXISTS dcps;'",
+      notify  => Exec['import-dcps-db']
+    }
+    
+    exec { 'import-cmon-db' :
+      onlyif  => [
+        "test -f ${clustercontrol::params::cmon_sql_path}/cmon_db.sql",
+        "test -f ${clustercontrol::params::cmon_sql_path}/cmon_data.sql"
       ],
-      command => "mysql -f -u root -p\"$mysql_cmon_root_password\" cmon < /tmp/configure_cmon_db.sql",
-      require => File["/tmp/configure_cmon_db.sql"]
-	  }
-	  
-	  file { '/tmp/configure_cmon_db.sql' :
-	     ensure  => present,
-	     content => template('clustercontrol/configure_cmon_db.sql.erb')
-	  }
-	  
-	  exec { "import-dcps-db" :
-	    onlyif  => "test -f $clustercontrol::params::wwwroot/clustercontrol/sql/dc-schema.sql",
-	    command => "mysql -f -u root -p\"$mysql_cmon_root_password\" dcps < $clustercontrol::params::wwwroot/clustercontrol/sql/dc-schema.sql",
-	  }
-	  
-	  file { $datadir :
-	    ensure  => directory,
-	    owner   => mysql, group => mysql,
-	    require => Package[$clustercontrol::params::mysql_packages],
-	    notify  => Service[$clustercontrol::params::mysql_service]
-	  }
-	  
-	  file { $clustercontrol::params::cmon_conf :
+      command => "mysql -f -u root -p\"${mysql_cmon_root_password}\" cmon < ${clustercontrol::params::cmon_sql_path}/cmon_db.sql && \
+	    mysql -f -u root -p\"${mysql_cmon_root_password}\" cmon < ${clustercontrol::params::cmon_sql_path}/cmon_data.sql",
+      notify => Exec['configure-cmon-db']
+    }
+    
+    exec { 'configure-cmon-db' :
+      onlyif  => [
+        "test -f ${clustercontrol::params::cmon_sql_path}/cmon_db.sql",
+        "test -f ${clustercontrol::params::cmon_sql_path}/cmon_data.sql"
+      ],
+      command => "mysql -f -u root -p\"${mysql_cmon_root_password}\" cmon < /tmp/configure_cmon_db.sql",
+      require => File['/tmp/configure_cmon_db.sql']
+    }
+    
+    file { '/tmp/configure_cmon_db.sql' :
+       ensure  => present,
+       content => template('clustercontrol/configure_cmon_db.sql.erb')
+    }
+    
+    exec { 'import-dcps-db' :
+      onlyif  => "test -f ${clustercontrol::params::wwwroot}/clustercontrol/sql/dc-schema.sql",
+      command => "mysql -f -u root -p\"${mysql_cmon_root_password}\" dcps < ${clustercontrol::params::wwwroot}/clustercontrol/sql/dc-schema.sql",
+    }
+    
+    file { $datadir :
+      ensure  => directory,
+      owner   => mysql,
+      group  => mysql,
+      require => Package[$clustercontrol::params::mysql_packages],
+      notify  => Service[$clustercontrol::params::mysql_service]
+    }
+    
+    file { $clustercontrol::params::cmon_conf :
       content => template('clustercontrol/cmon.cnf.erb'),
-      owner   => root, group => root,
-      mode    => 600,
+      owner   => root,
+      group   => root,
+      mode    => '0600',
       require => Package[$clustercontrol::params::cc_controller],
       notify  => [Exec['create-cmon-db'],Service['cmon']]
     }
-	  
-	  package { $clustercontrol::params::cc_controller :
-	    ensure => installed,
-	    require => [$clustercontrol::params::severalnines_repo,Package[$clustercontrol::params::cc_dependencies]]
-	  }
-	
-	  package { $clustercontrol::params::cc_dependencies :
-	    ensure  => installed,
-	    notify  => [
-	      Exec ['allow-override-all'],
-	      File [$clustercontrol::params::cert_file, $clustercontrol::params::key_file, $clustercontrol::params::apache_ssl_conf_file]
-	    ]
-	  }
-	  
-	  package { $clustercontrol::params::cc_ui : 
-	    ensure  => present, 
-	    require => Package[$clustercontrol::params::cc_controller],
-	    notify  => Exec['create-dcps-db']
-	  }
-	  
-	  package { $clustercontrol::params::cc_cmonapi : ensure => present, require => Package[$clustercontrol::params::cc_controller] }
-	  
-	  service { $clustercontrol::params::apache_service :
-	    ensure  => $service_status,
-	    enable  => $enabled,
-	    require => Package[$clustercontrol::params::cc_dependencies],
-	    hasrestart  => true,
-	    hasstatus   => true,
-	    subscribe  => File[$clustercontrol::params::apache_conf_file,$clustercontrol::params::apache_ssl_conf_file]
-	  }
-	  
-	  ssh_authorized_key { "$ssh_user" :
+    
+    package { $clustercontrol::params::cc_controller :
+      ensure => installed,
+      require => [$clustercontrol::params::severalnines_repo,Package[$clustercontrol::params::cc_dependencies]]
+    }
+  
+    package { $clustercontrol::params::cc_dependencies :
+      ensure=> installed,
+      notify=> [
+        Exec ['allow-override-all'],
+        File [$clustercontrol::params::cert_file, $clustercontrol::params::key_file, $clustercontrol::params::apache_ssl_conf_file]
+      ]
+    }
+    
+    package { $clustercontrol::params::cc_ui :
+      ensure  => present,
+      require => Package[$clustercontrol::params::cc_controller],
+      notify  => Exec['create-dcps-db']
+    }
+    
+    package { $clustercontrol::params::cc_cmonapi : ensure => present, require => Package[$clustercontrol::params::cc_controller] }
+    
+    service { $clustercontrol::params::apache_service :
+      ensure    => $service_status,
+      enable    => $enabled,
+      require   => Package[$clustercontrol::params::cc_dependencies],
+      hasrestart=> true,
+      hasstatus => true,
+      subscribe  => File[$clustercontrol::params::apache_conf_file,$clustercontrol::params::apache_ssl_conf_file]
+    }
+    
+    ssh_authorized_key { $ssh_user :
       ensure => present,
-      key    => generate('/bin/bash', "$modulepath/files/s9s_helper.sh", '--read-key', "$modulepath"),
-      name   => "$ssh_user@clustercontrol",
-      user   => "$ssh_user",
+      key    => generate('/bin/bash', "${modulepath}/files/s9s_helper.sh", '--read-key', $modulepath),
+      name   => "${ssh_user}@clustercontrol",
+      user   => $ssh_user,
       type   => 'ssh-rsa',
     }
-	  
-	  service { 'cmon' :
-	    ensure  => $service_status,
-	    enable  => $enabled,
-	    require => Package[
-	          $clustercontrol::params::cc_controller,
-	          $clustercontrol::params::cc_ui,
-	          $clustercontrol::params::cc_cmonapi
-	        ],
-	    subscribe    => File[$clustercontrol::params::cmon_conf],
-	    hasrestart   => true,
-	    hasstatus    => false
-	  }
-	  
-	  file { [
-	    "$clustercontrol::params::wwwroot/cmon/",
-	    "$clustercontrol::params::wwwroot/cmon/upload",
-	    "$clustercontrol::params::wwwroot/cmon/upload/schema"
-	  ] :
-	    ensure  => directory,
-	    recurse => true,
-	    owner   => $clustercontrol::params::apache_user,
-	    group   => $clustercontrol::params::apache_user,
-	    require => [Package[$clustercontrol::params::cc_ui],File["$ssh_identity", "$ssh_identity_pub"]],
-	    notify  => Service['cmon']
-	  }
-	  
-	  file { "$ssh_identity" :
-	    ensure => present,
-	    owner  => $ssh_user,
-	    group  => $ssh_user,
-	    mode   => 600,
-	    source => 'puppet:///modules/clustercontrol/id_rsa_s9s'
-	  }
-	  
-	  file { "$ssh_identity_pub" :
-	    ensure  => present,
-	    owner   => $ssh_user,
-	    group   => $ssh_user,
-	    mode    => 644,
-	    source  => 'puppet:///modules/clustercontrol/id_rsa_s9s.pub'
-	  }
-	  
-	  file { "$clustercontrol::params::wwwroot/cmonapi/config/bootstrap.php" :
-	    ensure  => present,
-	    replace => no,
-	    source  => "$clustercontrol::params::wwwroot/cmonapi/config/bootstrap.php.default",
-	    require => Package["$clustercontrol::params::cc_cmonapi"],
-	    notify  => Exec['configure-cmonapi-bootstrap']
-	  }
-	
-	  file { "$clustercontrol::params::wwwroot/cmonapi/config/database.php" :
-	    ensure  => present,
-	    content  => template('clustercontrol/database.php.erb'),
-	    require => Package["$clustercontrol::params::cc_cmonapi"]
-	  }
-	  
-	  file { "$clustercontrol::params::wwwroot/clustercontrol/bootstrap.php" :
-	    ensure  => present,
-	    replace => no,
-	    source  => "$clustercontrol::params::wwwroot/clustercontrol/bootstrap.php.default",
-	    require => Package["$clustercontrol::params::cc_ui"],
-	    notify  => Exec['configure-cc-bootstrap']
-	  }
-	  
-	  file { $clustercontrol::params::cert_file :
-	    ensure  => present,
-	    source  => "$clustercontrol::params::wwwroot/cmonapi/ssl/server.crt",
-	    require => Package["$clustercontrol::params::cc_cmonapi"]
-	  }
-	  
-	  file { $clustercontrol::params::key_file :
-	    ensure  => present,
-	    source  => "$clustercontrol::params::wwwroot/cmonapi/ssl/server.key",
-	    require => Package["$clustercontrol::params::cc_cmonapi"]
-	  }
-	  
-	  exec { "configure-cc-bootstrap" :
-	    command => "sed -i 's|DBPASS|$mysql_cmon_password|g' $clustercontrol::params::wwwroot/clustercontrol/bootstrap.php && \
-	    sed -i 's|DBPORT|$mysql_cmon_port|g' $clustercontrol::params::wwwroot/clustercontrol/bootstrap.php",
-	    notify => Service[$clustercontrol::params::apache_service]
-	  }
-	
-	  exec { "configure-cmonapi-bootstrap" :
-	    command => "sed -i 's|GENERATED_CMON_TOKEN|$api_token|g' $clustercontrol::params::wwwroot/cmonapi/config/bootstrap.php && \
-	    sed -i 's|clustercontrol.severalnines.com|$ip_address\/clustercontrol|g' $clustercontrol::params::wwwroot/cmonapi/config/bootstrap.php"
-	  }
-	  
-	  exec { "allow-override-all" :
-	    unless  => "grep 'AllowOverride All' $clustercontrol::params::apache_conf_file",
-	    command => "sed -i 's|AllowOverride None|AllowOverride All|g' $clustercontrol::params::apache_conf_file"
-	  }
     
-	} else {
-	  	  
-	  ssh_authorized_key { '$ssh_user' :
-	    ensure => present,
-	    key    => generate('/bin/bash', "$modulepath/files/s9s_helper.sh", '--read-key', "$modulepath"),
-	    name   => "$ssh_user@$clustercontrol_host",
-	    user   => "$ssh_user",
-	    type   => 'ssh-rsa',
-	    notify => Exec['grant-cmon-controller','grant-cmon-localhost','grant-cmon-127.0.0.1']
-	    }
-	  
-		exec { 'grant-cmon-controller' :
-		  onlyif  => 'which mysql',
-		  command => "mysql -u root -p\"$mysql_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"$clustercontrol_host\" IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-		  }
-		
-		exec { "grant-cmon-localhost" :
-		  onlyif  => 'which mysql',
-		  command => "mysql -u root -p\"$mysql_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@localhost IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
-		  }
+    service { 'cmon' :
+      ensure    => $service_status,
+      enable    => $enabled,
+      require   => Package[
+            $clustercontrol::params::cc_controller,
+            $clustercontrol::params::cc_ui,
+            $clustercontrol::params::cc_cmonapi
+          ],
+      subscribe => File[$clustercontrol::params::cmon_conf],
+      hasrestart=> true,
+      hasstatus => false
+    }
     
-    exec { "grant-cmon-127.0.0.1" :
-      onlyif => 'which mysql',
-      command => "mysql -u root -p\"$mysql_root_password\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@127.0.0.1 IDENTIFIED BY \"$mysql_cmon_password\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+    file { [
+      "${clustercontrol::params::wwwroot}/cmon/",
+      "${clustercontrol::params::wwwroot}/cmon/upload",
+      "${clustercontrol::params::wwwroot}/cmon/upload/schema"
+    ] :
+      ensure  => directory,
+      recurse => true,
+      owner   => $clustercontrol::params::apache_user,
+      group   => $clustercontrol::params::apache_user,
+      require => [Package[$clustercontrol::params::cc_ui],File[$ssh_identity, $ssh_identity_pub]],
+      notify  => Service['cmon']
+    }
+    
+    file { $ssh_identity :
+      ensure => present,
+      owner  => $ssh_user,
+      group  => $ssh_user,
+      mode   => '0600',
+      source => 'puppet:///modules/clustercontrol/id_rsa_s9s'
+    }
+    
+    file { $ssh_identity_pub :
+      ensure=> present,
+      owner => $ssh_user,
+      group => $ssh_user,
+      mode  => '0644',
+      source=> 'puppet:///modules/clustercontrol/id_rsa_s9s.pub'
+    }
+    
+    file { "${clustercontrol::params::wwwroot}/cmonapi/config/bootstrap.php" :
+      ensure  => present,
+      replace => no,
+      source  => "${clustercontrol::params::wwwroot}/cmonapi/config/bootstrap.php.default",
+      require => Package[$clustercontrol::params::cc_cmonapi],
+      notify  => Exec['configure-cmonapi-bootstrap']
+    }
+  
+    file { "${clustercontrol::params::wwwroot}/cmonapi/config/database.php" :
+      ensure  => present,
+      content=> template('clustercontrol/database.php.erb'),
+      require => Package[$clustercontrol::params::cc_cmonapi]
+    }
+    
+    file { "${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php" :
+      ensure  => present,
+      replace => no,
+      source  => "${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php.default",
+      require => Package[$clustercontrol::params::cc_ui],
+      notify  => Exec['configure-cc-bootstrap']
+    }
+    
+    file { $clustercontrol::params::cert_file :
+      ensure  => present,
+      source  => "${clustercontrol::params::wwwroot}/cmonapi/ssl/server.crt",
+      require => Package[$clustercontrol::params::cc_cmonapi]
+    }
+    
+    file { $clustercontrol::params::key_file :
+      ensure  => present,
+      source  => "${clustercontrol::params::wwwroot}/cmonapi/ssl/server.key",
+      require => Package[$clustercontrol::params::cc_cmonapi]
+    }
+    
+    exec { 'configure-cc-bootstrap' :
+      command => "sed -i 's|DBPASS|${mysql_cmon_password}|g' ${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php && \
+	    sed -i 's|DBPORT|${mysql_cmon_port}|g' ${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php",
+      notify => Service[$clustercontrol::params::apache_service]
+    }
+  
+    exec { 'configure-cmonapi-bootstrap' :
+      command => "sed -i 's|GENERATED_CMON_TOKEN|${api_token}|g' ${clustercontrol::params::wwwroot}/cmonapi/config/bootstrap.php && \
+	    sed -i 's|clustercontrol.severalnines.com|${ip_address}\/clustercontrol|g' ${clustercontrol::params::wwwroot}/cmonapi/config/bootstrap.php"
+    }
+    
+    exec { 'allow-override-all' :
+      unless  => "grep 'AllowOverride All' ${clustercontrol::params::apache_conf_file}",
+      command => "sed -i 's|AllowOverride None|AllowOverride All|g' ${clustercontrol::params::apache_conf_file}"
+    }
+    
+  } else {
+        
+    ssh_authorized_key { '$ssh_user' :
+      ensure => present,
+      key    => generate('/bin/bash', "${modulepath}/files/s9s_helper.sh", '--read-key', $modulepath),
+      name   => "${ssh_user}@${clustercontrol_host}",
+      user   => $ssh_user,
+      type   => 'ssh-rsa',
+      notify => Exec['grant-cmon-controller','grant-cmon-localhost','grant-cmon-127.0.0.1']
       }
-	}
+    
+    exec { 'grant-cmon-controller' :
+      onlyif  => 'which mysql',
+      command => "mysql -u root -p\"${mysql_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"${clustercontrol_host}\" IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+      }
+    
+    exec { 'grant-cmon-localhost' :
+      onlyif  => 'which mysql',
+      command => "mysql -u root -p\"${mysql_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@localhost IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+      }
+    
+    exec { 'grant-cmon-127.0.0.1' :
+      onlyif  => 'which mysql',
+      command => "mysql -u root -p\"${mysql_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@127.0.0.1 IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+      }
+  }
 }
 

--- a/clustercontrol/manifests/init.pp
+++ b/clustercontrol/manifests/init.pp
@@ -14,7 +14,7 @@
 class clustercontrol (
   $is_controller            = true,
   $clustercontrol_host      = '',
-  $ip_address               = $ipaddress,
+  $ip_address               = $::ipaddress,
   $api_token                = '',
   $ssh_user                 = 'root',
   $ssh_port                 = '22',
@@ -116,8 +116,8 @@ class clustercontrol (
     }
     
     exec { 'grant-cmon-fqdn' :
-      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -h\"${fqdn}\" status",
-      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"${fqdn}\" IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
+      unless  => "mysqladmin -u cmon -p \"${mysql_cmon_password}\" -h\"${::fqdn}\" status",
+      command => "mysql -u root -p\"${mysql_cmon_root_password}\" -e 'GRANT ALL PRIVILEGES ON *.* TO cmon@\"${::fqdn}\" IDENTIFIED BY \"${mysql_cmon_password}\" WITH GRANT OPTION; FLUSH PRIVILEGES;'",
     }
     
     exec { 'create-cmon-db' :

--- a/clustercontrol/manifests/init.pp
+++ b/clustercontrol/manifests/init.pp
@@ -64,11 +64,11 @@ class clustercontrol (
     include clustercontrol::params
     
     service { $clustercontrol::params::mysql_service :
-      ensure    => running,
-      enable    => true,
-      hasrestart=> true,
-      hasstatus => true,
-      require   => [
+      ensure     => running,
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => true,
+      require    => [
         Package[$clustercontrol::params::mysql_packages],
         File[$datadir],
         ],
@@ -77,16 +77,16 @@ class clustercontrol (
     }
     
     file { $clustercontrol::params::mysql_cnf :
-      ensure => present,
-      content=> template('clustercontrol/my.cnf.erb'),
-      owner  => root,
-      group  => root,
-      mode   => '0644'
+      ensure  => present,
+      content => template('clustercontrol/my.cnf.erb'),
+      owner   => root,
+      group   => root,
+      mode    => '0644'
       }
     
     package { $clustercontrol::params::mysql_packages :
-      ensure=> installed,
-      notify=> Exec['disable-extra-security']
+      ensure => installed,
+      notify => Exec['disable-extra-security']
     }
     
     exec { 'create-root-password' :
@@ -137,7 +137,7 @@ class clustercontrol (
       ],
       command => "mysql -f -u root -p\"${mysql_cmon_root_password}\" cmon < ${clustercontrol::params::cmon_sql_path}/cmon_db.sql && \
 	    mysql -f -u root -p\"${mysql_cmon_root_password}\" cmon < ${clustercontrol::params::cmon_sql_path}/cmon_data.sql",
-      notify => Exec['configure-cmon-db']
+      notify  => Exec['configure-cmon-db']
     }
     
     exec { 'configure-cmon-db' :
@@ -162,7 +162,7 @@ class clustercontrol (
     file { $datadir :
       ensure  => directory,
       owner   => mysql,
-      group  => mysql,
+      group   => mysql,
       require => Package[$clustercontrol::params::mysql_packages],
       notify  => Service[$clustercontrol::params::mysql_service]
     }
@@ -177,13 +177,13 @@ class clustercontrol (
     }
     
     package { $clustercontrol::params::cc_controller :
-      ensure => installed,
+      ensure  => installed,
       require => [$clustercontrol::params::severalnines_repo,Package[$clustercontrol::params::cc_dependencies]]
     }
   
     package { $clustercontrol::params::cc_dependencies :
-      ensure=> installed,
-      notify=> [
+      ensure => installed,
+      notify => [
         Exec ['allow-override-all'],
         File [$clustercontrol::params::cert_file, $clustercontrol::params::key_file, $clustercontrol::params::apache_ssl_conf_file]
       ]
@@ -198,11 +198,11 @@ class clustercontrol (
     package { $clustercontrol::params::cc_cmonapi : ensure => present, require => Package[$clustercontrol::params::cc_controller] }
     
     service { $clustercontrol::params::apache_service :
-      ensure    => $service_status,
-      enable    => $enabled,
-      require   => Package[$clustercontrol::params::cc_dependencies],
-      hasrestart=> true,
-      hasstatus => true,
+      ensure     => $service_status,
+      enable     => $enabled,
+      require    => Package[$clustercontrol::params::cc_dependencies],
+      hasrestart => true,
+      hasstatus  => true,
       subscribe  => File[$clustercontrol::params::apache_conf_file,$clustercontrol::params::apache_ssl_conf_file]
     }
     
@@ -215,16 +215,16 @@ class clustercontrol (
     }
     
     service { 'cmon' :
-      ensure    => $service_status,
-      enable    => $enabled,
-      require   => Package[
+      ensure     => $service_status,
+      enable     => $enabled,
+      require    => Package[
             $clustercontrol::params::cc_controller,
             $clustercontrol::params::cc_ui,
             $clustercontrol::params::cc_cmonapi
           ],
-      subscribe => File[$clustercontrol::params::cmon_conf],
-      hasrestart=> true,
-      hasstatus => false
+      subscribe  => File[$clustercontrol::params::cmon_conf],
+      hasrestart => true,
+      hasstatus  => false
     }
     
     file { [
@@ -249,11 +249,11 @@ class clustercontrol (
     }
     
     file { $ssh_identity_pub :
-      ensure=> present,
-      owner => $ssh_user,
-      group => $ssh_user,
-      mode  => '0644',
-      source=> 'puppet:///modules/clustercontrol/id_rsa_s9s.pub'
+      ensure => present,
+      owner  => $ssh_user,
+      group  => $ssh_user,
+      mode   => '0644',
+      source => 'puppet:///modules/clustercontrol/id_rsa_s9s.pub'
     }
     
     file { "${clustercontrol::params::wwwroot}/cmonapi/config/bootstrap.php" :
@@ -266,7 +266,7 @@ class clustercontrol (
   
     file { "${clustercontrol::params::wwwroot}/cmonapi/config/database.php" :
       ensure  => present,
-      content=> template('clustercontrol/database.php.erb'),
+      content => template('clustercontrol/database.php.erb'),
       require => Package[$clustercontrol::params::cc_cmonapi]
     }
     
@@ -293,7 +293,7 @@ class clustercontrol (
     exec { 'configure-cc-bootstrap' :
       command => "sed -i 's|DBPASS|${mysql_cmon_password}|g' ${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php && \
 	    sed -i 's|DBPORT|${mysql_cmon_port}|g' ${clustercontrol::params::wwwroot}/clustercontrol/bootstrap.php",
-      notify => Service[$clustercontrol::params::apache_service]
+      notify  => Service[$clustercontrol::params::apache_service]
     }
   
     exec { 'configure-cmonapi-bootstrap' :

--- a/clustercontrol/manifests/params.pp
+++ b/clustercontrol/manifests/params.pp
@@ -29,7 +29,7 @@ class clustercontrol::params {
       $apache_service   = 'httpd'
       $wwwroot          = '/var/www/html'
       $mysql_cnf        = '/etc/my.cnf'
-      
+
       yumrepo {
         's9s-repo':
           descr    => 'Severalnines Release Repository',
@@ -39,7 +39,7 @@ class clustercontrol::params {
           gpgcheck => 1
       }
       $severalnines_repo = Yumrepo['s9s-repo']
-      
+
       file { $apache_conf_file :
           ensure  => present,
           mode    => '0644',
@@ -48,25 +48,25 @@ class clustercontrol::params {
           require => Package[$cc_dependencies],
           notify  => Service[$apache_service]
           }
-      
+
       file { $apache_ssl_conf_file :
         ensure  => present,
         content => template('clustercontrol/ssl.conf.erb'),
         notify  => Service[$apache_service]
       }
-      
+
       file { '/etc/selinux/config':
         ensure  => present,
         content => template('clustercontrol/selinux-config.erb'),
       }
-      
+
       exec { 'disable-extra-security' :
         path    => ['/usr/sbin','/bin'],
         unless  => 'grep SELINUX=disabled /etc/sysconfig/selinux',
         command => 'setenforce 0',
         require => File['/etc/selinux/config']
       }
-      
+
     }
     'Debian': {
       if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease > 12) or ($::operatingsystem == 'Debian' and $::lsbmajdistrelease > 7){
@@ -76,7 +76,7 @@ class clustercontrol::params {
         $apache_ssl_conf_file = '/etc/apache2/sites-available/s9s-ssl.conf'
         $apache_ssl_target_file = '/etc/apache2/sites-enabled/001-s9s-ssl.conf'
         $extra_options     = 'Require all granted'
-       
+
         file { [
           '/etc/apache2/sites-enabled/000-default.conf',
           '/etc/apache2/sites-enabled/default-ssl.conf',
@@ -92,7 +92,7 @@ class clustercontrol::params {
         $apache_ssl_target_file = '/etc/apache2/sites-enabled/000-default-ssl'
         $extra_options     = ''
       }
-      
+
       $cert_file        = '/etc/ssl/certs/s9server.crt'
       $key_file         = '/etc/ssl/private/s9server.key'
       $apache_user      = 'www-data'
@@ -122,13 +122,13 @@ class clustercontrol::params {
         notify  => Exec['apt-update-severalnines']
       }
       $severalnines_repo = Exec['apt-update-severalnines']
-      
+
       exec { 'enable-apache-modules':
         path    => ['/usr/sbin','/sbin', '/usr/bin'],
         command => 'a2enmod ssl && a2enmod rewrite',
         require => Package[$cc_dependencies]
         }
-      
+
       file { $apache_conf_file :
           ensure  => present,
           content => template('clustercontrol/s9s.conf.erb'),
@@ -138,7 +138,7 @@ class clustercontrol::params {
           require => Package[$cc_ui],
           notify  => File[$apache_target_file]
         }
-      
+
       file { $apache_ssl_conf_file :
           ensure  => present,
           content => template('clustercontrol/s9s-ssl.conf.erb'),
@@ -148,17 +148,17 @@ class clustercontrol::params {
           require => Package[$cc_ui],
           notify  => File[$apache_ssl_target_file]
         }
-        
+
       file { $apache_ssl_target_file :
           ensure => 'link',
           target => $apache_ssl_conf_file
         }
-        
+
       file { $apache_target_file :
           ensure => 'link',
           target => $apache_conf_file
         }
-        
+
       exec { 'disable-extra-security' :
         path    => ['/usr/sbin', '/usr/bin'],
         onlyif  => 'which apparmor_status',

--- a/clustercontrol/manifests/params.pp
+++ b/clustercontrol/manifests/params.pp
@@ -1,3 +1,4 @@
+# Default parameters
 class clustercontrol::params {
   $repo_host = 'repo.severalnines.com'
   $cc_controller = 'clustercontrol-controller'

--- a/clustercontrol/manifests/params.pp
+++ b/clustercontrol/manifests/params.pp
@@ -6,9 +6,9 @@ class clustercontrol::params {
   $cmon_conf = '/etc/cmon.cnf'
   $cmon_sql_path    = '/usr/share/cmon'
   
-  case $osfamily {
+  case $::osfamily {
     'Redhat': {
-      if ($operatingsystemmajrelease > 6) {
+      if ($::operatingsystemmajrelease > 6) {
         $mysql_packages   = ['mariadb','mariadb-server']
         $mysql_service    = 'mariadb'
         $cc_dependencies  = [
@@ -69,7 +69,7 @@ class clustercontrol::params {
       
     }
     'Debian': {
-      if ($operatingsystem == 'Ubuntu' and $lsbmajdistrelease > 12) or ($operatingsystem == 'Debian' and $lsbmajdistrelease > 7){
+      if ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease > 12) or ($::operatingsystem == 'Debian' and $::lsbmajdistrelease > 7){
         $wwwroot          = '/var/www/html'
         $apache_conf_file = '/etc/apache2/sites-available/s9s.conf'
         $apache_target_file = '/etc/apache2/sites-enabled/001-s9s.conf'

--- a/clustercontrol/manifests/params.pp
+++ b/clustercontrol/manifests/params.pp
@@ -31,19 +31,20 @@ class clustercontrol::params {
       $mysql_cnf        = '/etc/my.cnf'
       
       yumrepo {
-        "s9s-repo":
-          descr     => "Severalnines Release Repository",
-          baseurl   => "http://$repo_host/rpm/os/x86_64",
-          enabled   => 1,
-          gpgkey    => "http://$repo_host/severalnines-repos.asc",
-          gpgcheck  => 1
+        's9s-repo':
+          descr    => 'Severalnines Release Repository',
+          baseurl  => "http://${repo_host}/rpm/os/x86_64",
+          enabled  => 1,
+          gpgkey   => "http://${repo_host}/severalnines-repos.asc",
+          gpgcheck => 1
       }
-      $severalnines_repo = Yumrepo["s9s-repo"]
+      $severalnines_repo = Yumrepo['s9s-repo']
       
       file { $apache_conf_file :
           ensure  => present,
-          mode    => 644,
-          owner   => root, group => root,
+          mode    => '0644',
+          owner   => root,
+          group   => root,
           require => Package[$cc_dependencies],
           notify  => Service[$apache_service]
           }
@@ -60,10 +61,10 @@ class clustercontrol::params {
       }
       
       exec { 'disable-extra-security' :
-        path        => ['/usr/sbin','/bin'],
-        unless      => 'grep SELINUX=disabled /etc/sysconfig/selinux',
-        command     => 'setenforce 0',
-        require     => File['/etc/selinux/config']
+        path    => ['/usr/sbin','/bin'],
+        unless  => 'grep SELINUX=disabled /etc/sysconfig/selinux',
+        command => 'setenforce 0',
+        require => File['/etc/selinux/config']
       }
       
     }
@@ -98,7 +99,7 @@ class clustercontrol::params {
       $apache_service   = 'apache2'
       $mysql_service    = 'mysql'
       $mysql_cnf        = '/etc/mysql/my.cnf'
-      $repo_list        = "deb [arch=amd64] http://$repo_host/deb ubuntu main"
+      $repo_list        = "deb [arch=amd64] http://${repo_host}/deb ubuntu main"
       $repo_source      = '/etc/apt/sources.list.d/s9s-repo.list'
       $mysql_packages   = ['mysql-client','mysql-server']
       $cc_dependencies  = [
@@ -108,58 +109,60 @@ class clustercontrol::params {
       exec { 'apt-update-severalnines' :
         path        => ['/bin','/usr/bin'],
         command     => 'apt-get update',
-        require     => File["$repo_source"],
+        require     => File[$repo_source],
         refreshonly => true
       }
       exec { 'import-severalnines-key' :
-        path        => ['/bin','/usr/bin'],
-        command     => "wget http://$repo_host/severalnines-repos.asc -O- | apt-key add -"
+        path    => ['/bin','/usr/bin'],
+        command => "wget http://${repo_host}/severalnines-repos.asc -O- | apt-key add -"
       }
-      file { "$repo_source":
-        content     => template('clustercontrol/s9s-repo.list.erb'),
-        require     => Exec['import-severalnines-key'],
-        notify      => Exec['apt-update-severalnines']
+      file { $repo_source:
+        content => template('clustercontrol/s9s-repo.list.erb'),
+        require => Exec['import-severalnines-key'],
+        notify  => Exec['apt-update-severalnines']
       }
       $severalnines_repo = Exec['apt-update-severalnines']
       
-      exec { 'enable-apache-modules': 
-        path  => ['/usr/sbin','/sbin', '/usr/bin'],
-        command => "a2enmod ssl && a2enmod rewrite",
+      exec { 'enable-apache-modules':
+        path    => ['/usr/sbin','/sbin', '/usr/bin'],
+        command => 'a2enmod ssl && a2enmod rewrite',
         require => Package[$cc_dependencies]
         }
       
       file { $apache_conf_file :
           ensure  => present,
           content => template('clustercontrol/s9s.conf.erb'),
-          mode    => 644,
-          owner   => root, group => root,
+          mode    => '0644',
+          owner   => root,
+          group   => root,
           require => Package[$cc_ui],
-          notify   => File[$apache_target_file]
+          notify  => File[$apache_target_file]
         }
       
       file { $apache_ssl_conf_file :
           ensure  => present,
           content => template('clustercontrol/s9s-ssl.conf.erb'),
-          mode    => 644,
-          owner   => root, group => root,
+          mode    => '0644',
+          owner   => root,
+          group   => root,
           require => Package[$cc_ui],
-          notify   => File[$apache_ssl_target_file]
+          notify  => File[$apache_ssl_target_file]
         }
         
       file { $apache_ssl_target_file :
           ensure => 'link',
-          target => "$apache_ssl_conf_file"
+          target => $apache_ssl_conf_file
         }
         
       file { $apache_target_file :
           ensure => 'link',
-          target => "$apache_conf_file"
+          target => $apache_conf_file
         }
         
       exec { 'disable-extra-security' :
-        path        => ['/usr/sbin', '/usr/bin'],
-        onlyif      => 'which apparmor_status',
-        command     => '/etc/init.d/apparmor stop; /etc/init.d/apparmor teardown; update-rc.d -f apparmor remove',
+        path    => ['/usr/sbin', '/usr/bin'],
+        onlyif  => 'which apparmor_status',
+        command => '/etc/init.d/apparmor stop; /etc/init.d/apparmor teardown; update-rc.d -f apparmor remove',
       }
     }
     default: {

--- a/clustercontrol/metadata.json
+++ b/clustercontrol/metadata.json
@@ -44,6 +44,7 @@
       "operatingsystem":"CentOS",
       "operatingsystemrelease":[ "6", "7" ]
     },
+    {
       "operatingsystem":"Debian",
       "operatingsystemrelease":[ "6", "7", "8" ]
     },

--- a/clustercontrol/metadata.json
+++ b/clustercontrol/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Installs ClusterControl, for your new database node/cluster deployment or on top of your existing database node/cluster.",
   "license": "Copyright (C) 2015 Severalnines AB. Licensed under the Licensed under (Apache 2.0).",
   "source": "https://github.com/severalnines/puppet",
-  "project_page": "(https://forge.puppetlabs.com/severalnines/clustercontrol)",
+  "project_page": "https://forge.puppetlabs.com/severalnines/clustercontrol",
   "issues_url": "https://github.com/severalnines/puppet/issues",
   "checksums": {
     "CHANGELOG": "d19853106bfa001f41ae172d79e96107",

--- a/clustercontrol/metadata.json
+++ b/clustercontrol/metadata.json
@@ -34,5 +34,26 @@
   ],
   "dependencies": [
   
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem":"RedHat",
+      "operatingsystemrelease":[ "6", "7" ]
+    },
+    {
+      "operatingsystem":"CentOS",
+      "operatingsystemrelease":[ "6", "7" ]
+    },
+      "operatingsystem":"Debian",
+      "operatingsystemrelease":[ "6", "7", "8" ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04 LTS",
+        "12.04 LTS",
+        "10.04 LTS"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This change looks massive, but it fixes almost lint problems with the code according to the [Puppet Style Guide](https://docs.puppet.com/guides/style_guide.html), mostly cosmetic stuff like indentation and quoting. There is no change to behaviour whatsoever.

The first batch of automatic fixing was done by [puppet-lint](http://puppet-lint.com/) and the rest I did by hand.

I also added a block of OS compatibility metadata based on the information provided in `README`.

These changes should get your [code quality score](https://forge.puppet.com/severalnines/clustercontrol/scores) above 0.4 / 5 and make it easier for people to contribute and more likely that they'll use it, too.

Cheers,
Jonathan
